### PR TITLE
Updated example

### DIFF
--- a/firmware/examples/2_Publish_voltage_readings.cpp
+++ b/firmware/examples/2_Publish_voltage_readings.cpp
@@ -8,16 +8,13 @@
 PowerShield batteryMonitor;
 
 void setup() {
-  
+  batteryMonitor.begin();
+  batteryMonitor.reset();
+  batteryMonitor.quickStart();
+  delay(1000);
 }
 
-void loop() {    
-
-
-    Wire.begin(); 
-    batteryMonitor.reset();
-    batteryMonitor.quickStart();
-    delay(1000);
+void loop() {
     float cellVoltage = batteryMonitor.getVCell();
     float stateOfCharge = batteryMonitor.getSoC();
     Spark.publish("ps-voltage", String(cellVoltage), 60, PRIVATE);
@@ -25,6 +22,4 @@ void loop() {
     Spark.publish("ps-soc", String(stateOfCharge), 60, PRIVATE);
     delay(100);
     System.sleep(SLEEP_MODE_DEEP, 600);
-
-
 }

--- a/spark.json
+++ b/spark.json
@@ -1,6 +1,6 @@
 {
     "name": "PowerShield",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "author": "Mohit Bhoite <mohit@particle.io>",
     "license": "LGPL",
     "description": "Library to support the fuel guage on the Power Shield"


### PR DESCRIPTION
- moved initialization stuff to setup()
- use .begin() from library and not Wire

Signed-off-by: Kenneth Lim kennethlimcp@gmail.com
